### PR TITLE
Switch subprocess parameters to support Python 3.6

### DIFF
--- a/run.py
+++ b/run.py
@@ -475,7 +475,13 @@ def _execute(command):
     This is a wrapper for ``subprocess.run()``.
 
     """
-    return subprocess.run(command, shell=True, capture_output=True, text=True)
+    return subprocess.run(
+        command,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
 
 
 def _print_warning(string):


### PR DESCRIPTION
The older versions of the parameters are functionally identical, just a bit more verbose. Might even work for earlier version, I only tested 3.6.